### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ rabbitmq-cluster Cookbook CHANGELOG
 ===========================
 
 ## v0.2.0
+
 FEBRUARY 1, 2015
+
 - Refactoring with LWRP
 - Enhanced checking logic for [#1]
 > If master node has included in the running nodes, it means node is already joined in `master_node_name` cluster. this feature has implemented by running shell script with grep before run join cluster. 
@@ -10,10 +12,13 @@ FEBRUARY 1, 2015
 - Some cleaning up of documentation.
 
 ## v0.1.2
+
 JANUARY 28, 2015
+
 - [#1] Ignore the error that happen when node is already been joined in clusser.
 
 ## v0.1.1
+
 - Adding default attributes for rabbitmq cookbook.
 >`['rabbitmq']['cluster'] = true` and `['rabbitmq']['erlang_cookie']` is required for configuring rabbitmq cluster. Also, all the cluster should have same erlang_cookie.
  - `default['rabbitmq']['cluster']` = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 rabbitmq-cluster Cookbook CHANGELOG
 ===========================
 
+## v0.3.0
+
+FEBRUARY 14, 2015
+
+- Refactoring
+
+- Ignore the cluster joining error that occurs when node has already joined in same cluster.
+> In this case, rabbitmqctl returns `{ok,already_member}` message.
+
+
 ## v0.2.0
 
 FEBRUARY 1, 2015

--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ rabbitmq-cluster cookbook has tested on the Vagrant box in below.
 ## Usage
 
 Please take look at the roles files and Vagrant file as an example.
+
 - rabbitmq general role (default attributes for installing rabbitmq) : https://github.com/sunggun-yu/chef-rabbitmq-cluster/blob/master/roles/rabbitmq.json
+
 - rabbitmq master role : https://github.com/sunggun-yu/chef-rabbitmq-cluster/blob/master/roles/rabbitmq_master.json
+
 - rabbitmq slave role : https://github.com/sunggun-yu/chef-rabbitmq-cluster/blob/master/roles/rabbitmq_master.json
+
 - Vagrant file (as a node attributes) : https://github.com/sunggun-yu/chef-rabbitmq-cluster/blob/master/Vagrantfile
 
 ### rabbitmq-cluster::default
@@ -79,18 +83,22 @@ There are 2 LWRP for RabbitMQ cluster
 
 ### Join cluster
 Join the slave node into the cluster. It will be skipped if node is master or node is already joined in cluster. 
+
 ```
 rabbitmq_cluster node['rabbitmq-cluster']['master_node_name'] do
   node_type node['rabbitmq-cluster']['node_type']
   action :join
 end
 ```
+
 - Required resources
  - `:cluster_name` : master node name. also, it is name attribute of LWRP.
  - `:node_type` : `master` or `slave`
 
+
 ### Change cluster node type
 Change the cluser node type (`ram` | `disc`). It will be skipped if node is master or not joined in cluster.
+
 ```
 rabbitmq_cluster node['rabbitmq-cluster']['master_node_name'] do
   node_type node['rabbitmq-cluster']['node_type']
@@ -98,6 +106,7 @@ rabbitmq_cluster node['rabbitmq-cluster']['master_node_name'] do
   action :change_cluster_node_type
 end
 ```
+
 - Required resources
  - `:cluster_name` : master node name. also, it is name attribute of LWRP.
  - `:node_type` : `master` or `slave`

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sunggun.dev@gmail.com'
 license          'Apache 2.0'
 description      'Configures rabbitmq cluster'
 long_description 'This cookbook configures rabbitmq cluster by executing rabbitmqctl command.'
-version          '0.2.0'
+version          '0.3.0'
 
 depends 'rabbitmq'
 


### PR DESCRIPTION
- Refactoring
- Ignore the cluster joining error that occurs when node has already joined in same cluster.
  
  > In this case, rabbitmqctl returns `{ok,already_member}` message.
